### PR TITLE
Fix for allocator bug, world thread adjustment

### DIFF
--- a/spacegame7/CGame.cxx
+++ b/spacegame7/CGame.cxx
@@ -314,7 +314,9 @@ void CGame::enter_world_loop(void)
 		//update world
 		this->m_pWorld->world_tick(flDelta);
 
-		std::this_thread::sleep_for(std::chrono::microseconds(500));
+		std::chrono::duration<float> sleep_duration = std::chrono::microseconds(250);
+
+		std::this_thread::sleep_for(sleep_duration);
 
 		if(this->m_bMainLoopContinue.load() == false)
 		{
@@ -359,7 +361,9 @@ void CGame::enter_script_loop(void)
 			this->core_fault(e);
 		}
 
-		std::this_thread::sleep_for(std::chrono::milliseconds(1));
+		std::chrono::duration<float> sleep_duration = std::chrono::milliseconds(1);
+
+		std::this_thread::sleep_for(sleep_duration);
 
 		if(this->m_bMainLoopContinue.load() == false)
 		{

--- a/spacegame7/CInSpaceState.cxx
+++ b/spacegame7/CInSpaceState.cxx
@@ -188,7 +188,7 @@ void CInSpaceState::state_initializing(void)
 
 	this->m_pScriptEngine->script_enqueue(this->m_szStartingScript.c_str());
 
-	//this->m_pScriptEngine->script_enqueue("data\\scripts\\stresstest.lua");
+	//this->m_pScriptEngine->script_enqueue("scripts\\stresstest.lua");
 
 	if (this->m_bRmsnEnabledForThisSession)
 	{

--- a/spacegame7/SGEngine.cxx
+++ b/spacegame7/SGEngine.cxx
@@ -42,10 +42,8 @@ InstanceId SGEngine::instance_request(unsigned int const uiSize)
 
 ALLOC_SEARCH:
 	//search for an unused pool block
-	while(get_block_flag(this->m_pPoolFlags[this->m_uiPoolPosition++], BLOCK_FLAG_ALLOCATED))
+	if(get_block_flag(this->m_pPoolFlags[this->m_uiPoolPosition], BLOCK_FLAG_ALLOCATED))
 	{
-		//++this->m_uiPoolPosition;
-
 		if (this->m_uiPoolPosition == DEFAULT_POOL_SIZE)
 		{
 			if (bTraversedOnce)
@@ -61,15 +59,25 @@ ALLOC_SEARCH:
 				//exception will be thrown
 				this->m_uiPoolPosition = 0;
 
-				break;
+				goto ALLOC_SEARCH_REEVALUATE;
 			}
 		}
 	}
+	else
+	{
+		goto ALLOC_SEARCH_CONCLUDED;
+	}
 
+	++this->m_uiPoolPosition;
+
+	goto ALLOC_SEARCH;
+
+ALLOC_SEARCH_REEVALUATE:
 	if(bTraversedOnce && this->m_uiPoolPosition == 0)
 	{
 		goto ALLOC_SEARCH;
 	}
+ALLOC_SEARCH_CONCLUDED:
 
 	//mark the block as allocated
 	set_block_flag(this->m_pPoolFlags[this->m_uiPoolPosition], BLOCK_FLAG_ALLOCATED);


### PR DESCRIPTION
The allocator can no longer potentially return blocks that are already in-use, resulting in memory corruption.

The world thread sleep duration was halved.