### PR TITLE
Add pausing, fixes to ingame menu

### DIFF
--- a/spacegame7/CBaseTransitionState.cxx
+++ b/spacegame7/CBaseTransitionState.cxx
@@ -49,3 +49,8 @@ bool CBaseTransitionState::state_terminated(void)
 {
 	return false;
 }
+
+bool CBaseTransitionState::state_game_paused(void)
+{
+	return false;
+}

--- a/spacegame7/CBaseTransitionState.hxx
+++ b/spacegame7/CBaseTransitionState.hxx
@@ -30,6 +30,8 @@ public:
 
 	virtual bool state_terminated(void) final;
 
+	virtual bool state_game_paused(void) final;
+
 	virtual void state_enable_input(bool const) final
 	{
 	};

--- a/spacegame7/CGame.cxx
+++ b/spacegame7/CGame.cxx
@@ -213,11 +213,11 @@ void CGame::enter_render_loop(void)
 		{
 			//tick character entities (spell cooldowns, etc)
 			this->m_pCharEntityManager->tick(flDelta);
-
-			//call do_sounds to clean up finished sounds, as well as
-			//play queued sounds
-			this->m_pAudioManager->do_sounds();
 		}
+
+		//call do_sounds to clean up finished sounds, as well as
+		//play queued sounds
+		this->m_pAudioManager->do_sounds();
 
 		//LOCK the window access mutex. This mutex should remain
 		//locked for the entire render operation.

--- a/spacegame7/CGame.hxx
+++ b/spacegame7/CGame.hxx
@@ -38,6 +38,7 @@ public:
 	void enter_main_loop(void);
 private:
 	std::atomic_bool m_bMainLoopContinue;
+	std::atomic_bool m_bGamePaused;
 
 	unsigned int resX;
 	unsigned int resY;

--- a/spacegame7/CGameExitState.cxx
+++ b/spacegame7/CGameExitState.cxx
@@ -1,0 +1,53 @@
+#include "CGameExitState.hxx"
+#include "BaseHubPanel.hxx"
+
+CGameExitState::CGameExitState()
+{
+}
+
+CGameExitState::~CGameExitState()
+{
+}
+
+void CGameExitState::state_initializing(void)
+{
+	this->m_bInitialized = true;
+}
+
+void CGameExitState::state_prerender_tick(sf::View&, sf::RenderWindow&, float const)
+{
+}
+
+void CGameExitState::state_render_world_tick(sf::View&, sf::RenderWindow&, float const)
+{
+}
+
+void CGameExitState::state_render_world_ui_tick(sf::View&, sf::RenderWindow&, float const)
+{
+}
+
+void CGameExitState::state_render_ui_tick(sf::View&, sf::RenderWindow&, float const)
+{
+}
+
+void CGameExitState::state_postrender_tick(sf::RenderWindow&, float const)
+{
+}
+
+void CGameExitState::state_terminating(void)
+{
+}
+
+void CGameExitState::state_process_event(sf::View&, sf::RenderWindow&, sf::Event&)
+{
+}
+
+bool CGameExitState::state_terminated(void)
+{
+	return true;
+}
+
+bool CGameExitState::state_game_paused(void)
+{
+	return false;
+}

--- a/spacegame7/CGameExitState.hxx
+++ b/spacegame7/CGameExitState.hxx
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "IGameState.hxx"
+#include "IEngine.hxx"
+#include "IRenderPipeline.hxx"
+#include "IScriptEngine.hxx"
+#include "IWorld.hxx"
+#include "ICamera.hxx"
+#include "CGameDataManager.hxx"
+#include "CShip.hxx"
+#include "InterfaceManager.hxx"
+#include "CAudioManager.hxx"
+#include "GLStarfield.hxx"
+#include "IUniverse.hxx"
+
+class CGameExitState : public IGameState
+{
+public:
+	CGameExitState();
+	~CGameExitState();
+
+	virtual void state_initializing(void) final;
+	virtual void state_prerender_tick(sf::View&, sf::RenderWindow&, float const) final;
+	virtual void state_render_world_tick(sf::View&, sf::RenderWindow&, float const) final;
+	virtual void state_render_world_ui_tick(sf::View&, sf::RenderWindow&, float const) final;
+	virtual void state_render_ui_tick(sf::View&, sf::RenderWindow&, float const) final;
+	virtual void state_postrender_tick(sf::RenderWindow&, float const) final;
+
+	virtual void state_terminating(void) final;
+	virtual void state_process_event(sf::View&, sf::RenderWindow&, sf::Event&) final;
+
+	virtual bool state_terminated(void) final;
+
+	virtual bool state_game_paused(void) final;
+
+	virtual void state_enable_input(bool const) final
+	{
+	};
+
+
+
+private:
+	Spinlock m_mFieldAccess;
+
+	bool m_bInitialized;
+
+	IEngine* m_pEngine;
+	IRenderPipeline* m_pRenderPipeline;
+	IWorld* m_pWorld;
+	IScriptEngine* m_pScriptEngine;
+	CGameDataManager* m_pGameDataManager;
+	InterfaceManager* m_pInterfaceManager;
+	CAudioManager* m_pAudioManager;
+	CParticleManager* m_pParticleManager;
+	CCommsManager* m_pCommsManager;
+};

--- a/spacegame7/CInSpaceState.cxx
+++ b/spacegame7/CInSpaceState.cxx
@@ -469,11 +469,11 @@ void CInSpaceState::state_process_event(sf::View &mainView, sf::RenderWindow &sf
 		return;
 	}
 
-	if(!this->m_pInterfaceManager->input_blocked())
+	if(sfEvent.type == sf::Event::MouseButtonPressed)
 	{
-		if(sfEvent.type == sf::Event::MouseButtonPressed)
+		if(this->m_pPlayer)
 		{
-			if(this->m_pPlayer)
+			if(!this->m_pInterfaceManager->input_blocked())
 			{
 				/*
 				 * We detected a left mouse down event. Convert to world coordinates and pass these to the
@@ -508,9 +508,12 @@ void CInSpaceState::state_process_event(sf::View &mainView, sf::RenderWindow &sf
 				}
 			}
 		}
-		else if(sfEvent.type == sf::Event::KeyPressed)
+	}
+	else if(sfEvent.type == sf::Event::KeyPressed)
+	{
+		if(this->m_pPlayer)
 		{
-			if(this->m_pPlayer)
+			if(!this->m_pInterfaceManager->input_blocked())
 			{
 				for(int i = 1; i <= 10; ++i)
 				{

--- a/spacegame7/CInSpaceState.cxx
+++ b/spacegame7/CInSpaceState.cxx
@@ -40,7 +40,8 @@ CInSpaceState::CInSpaceState(char const *startingScript, SectorId sectorId, Vect
 	m_szPlayerName(SG::get_intransient_data_manager()->get_character_entity_manager()->get_player_character_entity()->get_name()),
 	m_bRmsnEnabledForThisSession(false),
 	m_szRmsnScript(""),
-	m_uiSectorId(sectorId)
+	m_uiSectorId(sectorId),
+	m_bGamePaused(false)
 {
 	this->m_pEngine = SG::get_engine();
 	this->m_pRenderPipeline = SG::get_render_pipeline();
@@ -1049,4 +1050,12 @@ void CInSpaceState::set_rmsn_script(std::string const& szRmsnScript)
 
 	this->m_bRmsnEnabledForThisSession = true;
 	this->m_szRmsnScript = szRmsnScript;
+}
+
+bool CInSpaceState::state_game_paused(void)
+{
+	SCOPE_LOCK(this->m_mFieldAccess);
+
+	//TODO: for now, pause the game whenever interface manager reports input block
+	return this->m_pInterfaceManager->input_blocked();
 }

--- a/spacegame7/CInSpaceState.hxx
+++ b/spacegame7/CInSpaceState.hxx
@@ -40,6 +40,8 @@ public:
 
 	virtual bool state_terminated(void) final;
 
+	virtual bool state_game_paused(void) final;
+
 	virtual void state_enable_input(bool const) final;
 
 	virtual void state_send_notification(std::string const &) final;
@@ -70,6 +72,8 @@ private:
 	* ACCESSING
 	*/
 	bool m_bInputEnabled;
+
+	bool m_bGamePaused;
 
 	bool m_bRmsnEnabledForThisSession;
 	std::string m_szRmsnScript;

--- a/spacegame7/CLandedState.cxx
+++ b/spacegame7/CLandedState.cxx
@@ -49,3 +49,8 @@ bool CLandedState::state_terminated(void)
 {
 	return false;
 }
+
+bool CLandedState::state_game_paused(void)
+{
+	return false;
+}

--- a/spacegame7/CLandedState.hxx
+++ b/spacegame7/CLandedState.hxx
@@ -31,9 +31,13 @@ public:
 
 	virtual bool state_terminated(void) final;
 
+	virtual bool state_game_paused(void) final;
+
 	virtual void state_enable_input(bool const) final
 	{
 	};
+
+
 
 private:
 	bool m_bIngameMenuOpen;

--- a/spacegame7/CMainMenuState.cxx
+++ b/spacegame7/CMainMenuState.cxx
@@ -76,3 +76,7 @@ bool CMainMenuState::state_terminated(void)
 	return this->m_bInitialized && SG::get_interface_manager()->get_num_panels() == 0;
 }
 
+bool CMainMenuState::state_game_paused(void)
+{
+	return false;
+}

--- a/spacegame7/CMainMenuState.hxx
+++ b/spacegame7/CMainMenuState.hxx
@@ -24,6 +24,8 @@ public:
 
 	virtual bool state_terminated(void) final;
 
+	virtual bool state_game_paused(void) final;
+
 private:
 	sf::VertexArray m_sfBgVerts;
 	sf::Shader m_sfBackgroundShader;

--- a/spacegame7/CSectorTransitionState.cxx
+++ b/spacegame7/CSectorTransitionState.cxx
@@ -49,3 +49,8 @@ bool CSectorTransitionState::state_terminated(void)
 {
 	return false;
 }
+
+bool CSectorTransitionState::state_game_paused(void)
+{
+	return false;
+}

--- a/spacegame7/CSectorTransitionState.hxx
+++ b/spacegame7/CSectorTransitionState.hxx
@@ -29,6 +29,7 @@ public:
 	virtual void state_process_event(sf::View &, sf::RenderWindow &, sf::Event &) final;
 
 	virtual bool state_terminated(void) final;
+	virtual bool state_game_paused(void) final;
 
 	virtual void state_enable_input(bool const) final
 	{

--- a/spacegame7/IGameState.hxx
+++ b/spacegame7/IGameState.hxx
@@ -25,4 +25,5 @@ interface IGameState
 	virtual void state_send_notification(std::string const &) {};
 
 	virtual bool state_terminated(void) = 0;
+	virtual bool state_game_paused(void) = 0;
 };

--- a/spacegame7/InGameMenuPanel.cxx
+++ b/spacegame7/InGameMenuPanel.cxx
@@ -1,0 +1,50 @@
+#include "InGameMenuPanel.hxx"
+#include "SGLib.hxx"
+#include "CMainMenuState.hxx"
+#include "CGameExitState.hxx"
+
+bool InGameMenuPanel::m_bPanelExists = false;
+
+InGameMenuPanel::InGameMenuPanel()
+{
+	if(this->m_bPanelExists)
+	{
+		this->m_bPanelActive = false;
+	}
+	else
+	{
+		this->m_bPanelActive = true;
+		this->m_bPanelExists = true;
+	}
+}
+
+InGameMenuPanel::~InGameMenuPanel()
+{
+	this->m_bPanelExists = false;
+}
+
+void InGameMenuPanel::render_panel(float const flDelta)
+{
+	ImGui::SetNextWindowPosCenter(ImGuiCond_Once | ImGuiCond_Appearing);
+
+	ImGui::Begin(
+		"In-Game Menu",
+		nullptr,
+		ImGuiWindowFlags_AlwaysAutoResize |
+		ImGuiWindowFlags_NoTitleBar |
+		ImGuiWindowFlags_NoResize |
+		ImGuiWindowFlags_NoCollapse
+	);
+
+	if(ImGui::Button("Exit to Menu"))
+	{
+		SG::get_game_state_manager()->transition_game_state(new CMainMenuState);
+	}
+
+	if(ImGui::Button("Exit to Desktop"))
+	{
+		SG::get_game_state_manager()->transition_game_state(new CGameExitState);
+	}
+
+	ImGui::End();
+}

--- a/spacegame7/InGameMenuPanel.hxx
+++ b/spacegame7/InGameMenuPanel.hxx
@@ -1,47 +1,25 @@
 #pragma once
 
 #include "InterfacePanel.hxx"
-#include "SGLib.hxx"
-#include "CMainMenuState.hxx"
 
 class InGameMenuPanel : public InterfacePanel
 {
 public:
-	InGameMenuPanel()
-	{};
-	virtual ~InGameMenuPanel()
-	{};
+	InGameMenuPanel();
+	virtual ~InGameMenuPanel();
 
-	virtual void render_panel(float const flDelta)
-	{
-		ImGui::SetNextWindowPosCenter(ImGuiCond_Once | ImGuiCond_Appearing);
-
-		ImGui::Begin(
-			"In-Game Menu",
-			nullptr,
-			ImGuiWindowFlags_AlwaysAutoResize |
-			ImGuiWindowFlags_NoTitleBar |
-			ImGuiWindowFlags_NoResize |
-			ImGuiWindowFlags_NoCollapse
-		);
-
-		if (ImGui::Button("Exit to Menu"))
-		{
-			SG::get_game_state_manager()->transition_game_state(new CMainMenuState);
-		}
-
-		ImGui::Button("Exit to Desktop");
-
-		ImGui::End();
-	};
+	virtual void render_panel(float const);
 
 	virtual bool panel_active(void)
 	{
-		return true;
+		return this->m_bPanelActive;
 	};
 
 	virtual bool prevents_game_input(void)
 	{
 		return true;
 	};
+private:
+	bool m_bPanelActive;
+	static bool m_bPanelExists;
 };

--- a/spacegame7/InterfaceManager.cxx
+++ b/spacegame7/InterfaceManager.cxx
@@ -78,6 +78,11 @@ void InterfaceManager::free_all_panels(void)
 
 	for(InterfacePanel *pPanel : this->m_vPanels)
 	{
+		if(pPanel->prevents_game_input())
+		{
+			--this->m_iInputHinderingPanelCount;
+		}
+
 		delete pPanel;
 	}
 

--- a/spacegame7/spacegame7.vcxproj
+++ b/spacegame7/spacegame7.vcxproj
@@ -203,6 +203,7 @@
     <ClCompile Include="CGame.cxx" />
     <ClCompile Include="CGameClock.cxx" />
     <ClCompile Include="CGameDataManager.cxx" />
+    <ClCompile Include="CGameExitState.cxx" />
     <ClCompile Include="CGameSettings.cxx" />
     <ClCompile Include="CGameStateManager.cxx" />
     <ClCompile Include="CGameWorld.cxx" />
@@ -264,6 +265,7 @@
     <ClCompile Include="EquipTraderPanel.cxx" />
     <ClCompile Include="IMaterial.cxx" />
     <ClCompile Include="IMaterialClass.cxx" />
+    <ClCompile Include="InGameMenuPanel.cxx" />
     <ClCompile Include="JunkTraderPanel.cxx" />
     <ClCompile Include="LoadGamePanel.cxx" />
     <ClCompile Include="MaterialBankPanel.cxx" />
@@ -320,6 +322,7 @@
     <ClInclude Include="CGame.hxx" />
     <ClInclude Include="CGameClock.hxx" />
     <ClInclude Include="CGameDataManager.hxx" />
+    <ClInclude Include="CGameExitState.hxx" />
     <ClInclude Include="CGameStateManager.hxx" />
     <ClInclude Include="CGameWorld.hxx" />
     <ClInclude Include="Character.hxx" />

--- a/spacegame7/spacegame7.vcxproj.filters
+++ b/spacegame7/spacegame7.vcxproj.filters
@@ -424,6 +424,12 @@
     <ClCompile Include="DebugCommands.cxx">
       <Filter>Engine\Debug</Filter>
     </ClCompile>
+    <ClCompile Include="CGameExitState.cxx">
+      <Filter>Engine\GameState</Filter>
+    </ClCompile>
+    <ClCompile Include="InGameMenuPanel.cxx">
+      <Filter>Engine\Interface</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="IEngine.hxx">
@@ -959,6 +965,9 @@
     </ClInclude>
     <ClInclude Include="DebugCommands.hxx">
       <Filter>Engine\Debug</Filter>
+    </ClInclude>
+    <ClInclude Include="CGameExitState.hxx">
+      <Filter>Engine\GameState</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Game class now supports pausing. New function `IGameState::state_game_paused`, when returns true, causes the world and script threads to stop ticking the world and script engine, respectively, and the render thread to stop ticking the entity manager.

`CInSpaceState` returns `true` from this function when the interface manager indicates input should be blocked. This can be changed later.

Ingame menu 'Exit to Desktop' button now causes the game to exit. The player should have been able to press ESC again to close the menu after opening it, but a bug in the logic prevented this from happening. Now, the player can press ESC to close the menu.