### PR TITLE
Changes to notifications, input

### DIFF
--- a/assets/scripts/rmsns/bremerhaven.lua
+++ b/assets/scripts/rmsns/bremerhaven.lua
@@ -126,5 +126,6 @@ end
 
 function mission_transfer_reward()
 	sgs_player_adjust_money(2000)
+	sgs_send_notification("Money: +2000")
 	sgs_waypoint_set(0, 0)
 end

--- a/assets/scripts/rmsns/spire.lua
+++ b/assets/scripts/rmsns/spire.lua
@@ -126,5 +126,6 @@ end
 
 function mission_transfer_reward()
 	sgs_player_adjust_money(5000)
+	sgs_send_notification("Money: +5000")
 	sgs_waypoint_set(0, 0)
 end

--- a/assets/scripts/rmsns/whitney.lua
+++ b/assets/scripts/rmsns/whitney.lua
@@ -252,4 +252,5 @@ end
 
 function mission_actually_give_money()
 	sgs_player_adjust_money(10000)
+	sgs_send_notification("Money: +10000")
 end

--- a/spacegame7/CInSpaceState.cxx
+++ b/spacegame7/CInSpaceState.cxx
@@ -46,7 +46,8 @@ CInSpaceState::CInSpaceState(char const *startingScript, SectorId sectorId, Vect
 	m_bRmsnEnabledForThisSession(false),
 	m_szRmsnScript(""),
 	m_uiSectorId(sectorId),
-	m_bGamePaused(false)
+	m_bGamePaused(false),
+	m_bTrackMode(true)
 {
 	this->m_pEngine = SG::get_engine();
 	this->m_pRenderPipeline = SG::get_render_pipeline();

--- a/spacegame7/CInSpaceState.cxx
+++ b/spacegame7/CInSpaceState.cxx
@@ -266,7 +266,7 @@ void CInSpaceState::state_prerender_tick(sf::View &mainView, sf::RenderWindow &s
 	}
 
 	//BEGIN TESTING CODE
-	if (this->m_pPlayer)
+	if (sfWindow.hasFocus() && this->m_pPlayer)
 	{
 		sf::Vector2i mousePos = sf::Mouse::getPosition(sfWindow);
 

--- a/spacegame7/CInSpaceState.hxx
+++ b/spacegame7/CInSpaceState.hxx
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <queue>
+
 #include "Defs.hxx"
 #include "IGameState.hxx"
 #include "IEngine.hxx"
@@ -150,4 +152,6 @@ private:
 	bool m_flDeathScreenSpawned;
 	bool m_bTrackMode;
 	SectorId m_uiSectorId;
+
+	std::queue<std::string> m_qNotificationQueue;
 };

--- a/spacegame7/LuaCallbacks.cxx
+++ b/spacegame7/LuaCallbacks.cxx
@@ -1560,6 +1560,32 @@ extern "C"
 
 		return 1;
 	}
+
+	/*
+	* Callback for send_notification
+	*/
+	static int sgs::send_notification(lua_State* L)
+	{
+		int n = lua_gettop(L);
+
+		if(n != 1)
+		{
+			lua_pushstring(L, "incorrect number of arguments");
+			lua_error(L);
+		}
+
+		if(!lua_isstring(L, 1))
+		{
+			lua_pushstring(L, "incorrect arg types");
+			lua_error(L);
+		}
+
+		char const* szText = lua_tostring(L, 1);
+
+		SG::get_game_state_manager()->get_game_state()->state_send_notification(std::string(szText));
+
+		return 0;
+	}
 }
 
 /*
@@ -1611,6 +1637,7 @@ void sgs::register_callbacks(void)
 	pScriptEngine->register_callback("sgs_map_add_circle", &sgs::map_add_circle);
 	pScriptEngine->register_callback("sgs_map_add_zone_rectangular", &sgs::map_add_zone_rectangular);
 	pScriptEngine->register_callback("sgs_map_add_zone_circular", &sgs::map_add_zone_circular);
+	pScriptEngine->register_callback("sgs_send_notification", &sgs::send_notification);
 }
 
 /*

--- a/spacegame7/LuaCallbacks.hxx
+++ b/spacegame7/LuaCallbacks.hxx
@@ -57,6 +57,8 @@ extern "C"
 		static int map_add_circle(lua_State*);
 		static int map_add_zone_circular(lua_State*);
 		static int map_add_zone_rectangular(lua_State*);
+		
+		static int send_notification(lua_State*);
 	}
 }
 

--- a/spacegame7/NotificationPanel.cxx
+++ b/spacegame7/NotificationPanel.cxx
@@ -1,14 +1,14 @@
 #include "NotificationPanel.hxx"
 
-#define NOTIFICATION_DURATION 2.5
-#define NOTIFICATION_SCROLL_SPEED 15.0f
+#define NOTIFICATION_DURATION 2.5f
+#define NOTIFICATION_SCROLL_SPEED 10.0f
 
 void NotificationPanel::render_panel(float const flDelta)
 {
 	ImVec2 displaySize = ImGui::GetIO().DisplaySize;
 
 	ImVec2 textSize = ImGui::CalcTextSize(this->m_szText.c_str());
-	ImGui::SetNextWindowPos(ImVec2(displaySize.x / 2.0f - textSize.x / 2.0f, displaySize.y / 3.0f - this->m_flDuration * NOTIFICATION_SCROLL_SPEED), ImGuiCond_Always);
+	ImGui::SetNextWindowPos(ImVec2(displaySize.x / 2.0f - textSize.x / 2.0f, displaySize.y / 3.75f + clamp(2.5f - this->m_flDuration, 0.0f, 1.0f) * NOTIFICATION_SCROLL_SPEED), ImGuiCond_Always);
 
 	ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);
 

--- a/spacegame7/NotificationPanel.cxx
+++ b/spacegame7/NotificationPanel.cxx
@@ -1,0 +1,44 @@
+#include "NotificationPanel.hxx"
+
+#define NOTIFICATION_DURATION 2.5
+#define NOTIFICATION_SCROLL_SPEED 15.0f
+
+void NotificationPanel::render_panel(float const flDelta)
+{
+	ImVec2 displaySize = ImGui::GetIO().DisplaySize;
+
+	ImVec2 textSize = ImGui::CalcTextSize(this->m_szText.c_str());
+	ImGui::SetNextWindowPos(ImVec2(displaySize.x / 2.0f - textSize.x / 2.0f, displaySize.y / 3.0f - this->m_flDuration * NOTIFICATION_SCROLL_SPEED), ImGuiCond_Always);
+
+	ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);
+
+	ImGui::Begin(
+		"Notification",
+		nullptr,
+		ImVec2(100.0f, 100.0f),
+		0.0f,
+		ImGuiWindowFlags_AlwaysAutoResize |
+		ImGuiWindowFlags_NoTitleBar |
+		ImGuiWindowFlags_NoResize |
+		ImGuiWindowFlags_NoCollapse |
+		ImGuiWindowFlags_NoScrollbar |
+		ImGuiWindowFlags_NoSavedSettings |
+		ImGuiWindowFlags_NoInputs |
+		ImGuiWindowFlags_NoMove |
+		ImGuiWindowFlags_NoBringToFrontOnFocus |
+		ImGuiWindowFlags_NoFocusOnAppearing
+	);
+
+	ImGui::TextColored(ImVec4(1.0f, 1.0f, 1.0f, clamp(2.5f - this->m_flDuration, 0.0f, 1.0f)), this->m_szText.c_str());
+
+	ImGui::End();
+
+	ImGui::PopStyleVar();
+
+	this->m_flDuration += flDelta;
+
+	if(this->m_flDuration > NOTIFICATION_DURATION)
+	{
+		this->m_bActive = false;
+	}
+}

--- a/spacegame7/NotificationPanel.hxx
+++ b/spacegame7/NotificationPanel.hxx
@@ -4,8 +4,6 @@
 #include "SGLib.hxx"
 #include "CMainMenuState.hxx"
 
-#define NOTIFICATION_DURATION 1.5
-
 class NotificationPanel : public InterfacePanel
 {
 public:
@@ -15,45 +13,7 @@ public:
 	virtual ~NotificationPanel()
 	{};
 
-	virtual void render_panel(float const flDelta)
-	{
-		ImVec2 displaySize = ImGui::GetIO().DisplaySize;
-
-		ImVec2 textSize = ImGui::CalcTextSize(this->m_szText.c_str());
-		ImGui::SetNextWindowPos(ImVec2(displaySize.x / 2.0f - textSize.x / 2.0f, displaySize.y / 3.0f - this->m_flDuration * 20.0f), ImGuiCond_Always);
-
-		ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);
-
-		ImGui::Begin(
-			"Notification",
-			nullptr,
-			ImVec2(100.0f, 100.0f),
-			0.0f,
-			ImGuiWindowFlags_AlwaysAutoResize |
-			ImGuiWindowFlags_NoTitleBar |
-			ImGuiWindowFlags_NoResize |
-			ImGuiWindowFlags_NoCollapse |
-			ImGuiWindowFlags_NoScrollbar |
-			ImGuiWindowFlags_NoSavedSettings |
-			ImGuiWindowFlags_NoInputs |
-			ImGuiWindowFlags_NoMove |
-			ImGuiWindowFlags_NoBringToFrontOnFocus |
-			ImGuiWindowFlags_NoFocusOnAppearing
-		);
-		
-		ImGui::TextColored(ImVec4(1.0f, 1.0f, 1.0f, clamp(1.5f - this->m_flDuration, 0.0f, 1.0f)), this->m_szText.c_str());
-
-		ImGui::End();
-
-		ImGui::PopStyleVar();
-
-		this->m_flDuration += flDelta;
-
-		if(this->m_flDuration > NOTIFICATION_DURATION)
-		{
-			this->m_bActive = false;
-		}
-	};
+	virtual void render_panel(float const);
 
 	virtual bool panel_active(void)
 	{

--- a/spacegame7/spacegame7.vcxproj
+++ b/spacegame7/spacegame7.vcxproj
@@ -271,6 +271,7 @@
     <ClCompile Include="LoadGamePanel.cxx" />
     <ClCompile Include="MaterialBankPanel.cxx" />
     <ClCompile Include="MaterialExaminePanel.cxx" />
+    <ClCompile Include="NotificationPanel.cxx" />
     <ClCompile Include="PlayerDiedPanel.cxx" />
     <ClCompile Include="SaveGamePanel.cxx" />
     <ClCompile Include="SectorMapPanel.cxx" />

--- a/spacegame7/spacegame7.vcxproj.filters
+++ b/spacegame7/spacegame7.vcxproj.filters
@@ -433,6 +433,9 @@
     <ClCompile Include="CLoadingScreenState.cxx">
       <Filter>Engine\GameState</Filter>
     </ClCompile>
+    <ClCompile Include="NotificationPanel.cxx">
+      <Filter>Engine\Interface</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="IEngine.hxx">


### PR DESCRIPTION
Notifications are shown on the screen for a longer time. In addition, their presentation was altered slightly to make them more noticeable and readable.

Mission payouts now send a notification, telling the player exactly how much money they received.

The game now checks whether the game window has focus before processing certain types of input, namely ship controls.