### PR TITLE
Various UI fixes, improved savegame loading

### DIFF
--- a/spacegame7/CEquipInstance.hxx
+++ b/spacegame7/CEquipInstance.hxx
@@ -153,6 +153,12 @@ public:
 		
 	};
 
+	float get_refire_time_remaining(void)
+	{
+		SCOPE_LOCK(this->m_mFieldAccess);
+		return this->m_flRefireTimeRemaining;
+	};
+
 	void fire(void);
 
 private:

--- a/spacegame7/CGameDataManager.hxx
+++ b/spacegame7/CGameDataManager.hxx
@@ -4,6 +4,7 @@
 #include <list>
 #include <random>
 #include <mutex>
+#include <future>
 
 #include "Archetype.hxx"
 #include "Loadout.hxx"
@@ -48,7 +49,7 @@ public:
 	static void load_all_loottables(ILootTableManager *);
 	static void load_all_resource_classes(IMatManager *);
 
-	static void load_from_save(std::string const &);
+	static std::future<bool> load_from_save(std::string const &);
 	static void dump_to_save(std::string const &, BaseId const);
 
 	void load_shiparch_data(void);
@@ -201,12 +202,14 @@ public:
 
 	static std::string get_full_data_file_path(std::string const &);
 
+	static bool get_directory_exists(std::string const&);
+
 private:
 	static bool settingsLoaded;
 
 	static void load_settings_data(void);
 
-	static void load_from_save_delegate(std::string const&);
+	static bool load_from_save_delegate(std::string const&);
 	static void dump_to_save_delegate(std::string const&, BaseId const);
 
 	static void rough_touch_file(std::string const&);

--- a/spacegame7/LoadGamePanel.cxx
+++ b/spacegame7/LoadGamePanel.cxx
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <future>
+
 #include "SGLib.hxx"
 #include "ICharacterEntity.hxx"
 #include "LoadGamePanel.hxx"
@@ -7,12 +9,33 @@
 
 bool LoadGamePanel::m_bPanelExists = false;
 
+LoadGamePanel::LoadGamePanel()
+	: m_bLoadingOperationInitiated(false)
+{
+	if(this->m_bPanelExists)
+	{
+		this->m_bPanelActive = false;
+	}
+	else
+	{
+		this->m_bPanelActive = true;
+		this->m_bPanelExists = true;
+	}
+}
+
+LoadGamePanel::~LoadGamePanel()
+{
+	this->m_bPanelExists = false;
+}
+
 void LoadGamePanel::render_panel(float const flDelta)
 {
 	if (!this->m_bPanelExists)
 	{
 		return;
 	}
+
+	static std::string loadFailedPopupText("");
 
 	ImGui::SetNextWindowPosCenter(ImGuiCond_Once | ImGuiCond_Appearing);
 
@@ -32,13 +55,64 @@ void LoadGamePanel::render_panel(float const flDelta)
 
 	ImGui::InputText("Name", szCharName, 16, ImGuiInputTextFlags_CharsNoBlank);
 
-	if (ImGui::Button("Load"))
+	if(!this->m_bLoadingOperationInitiated)
 	{
-		std::stringstream ss;
-		ss << "saves\\";
-		ss << szCharName;
-		ss << ".sav";
-		SG::get_game_data_manager()->load_from_save(ss.str());
+		if(ImGui::Button("Load"))
+		{
+			if(CGameDataManager::get_directory_exists("saves"))
+			{
+				std::stringstream ss;
+				ss << "saves\\";
+				ss << szCharName;
+				ss << ".sav";
+
+				this->m_fLoadingOperationResult = SG::get_game_data_manager()->load_from_save(ss.str());
+				this->m_bLoadingOperationInitiated = true;
+			}
+			else
+			{
+				ImGui::OpenPopup("Load Failed");
+
+				loadFailedPopupText = "Saves directory does not exist.\nPlease create the directory and try again.";
+			}
+		}
+	}
+	else
+	{
+		//check async load operation status
+		if(this->m_fLoadingOperationResult.wait_for(std::chrono::seconds(0)) == std::future_status::ready)
+		{
+			if(this->m_fLoadingOperationResult.get() == true)
+			{
+				//the load operation succeeded.
+				//in practice, this piece of code will probably never be reached,
+				//because the interface manager will be shifted out as a result of the
+				//load operation, but just in case, we will delete ourself.
+
+				this->m_bPanelActive = false;
+			}
+			else
+			{
+				ImGui::OpenPopup("Load Failed");
+
+				loadFailedPopupText = "Save file not found, or is invalid.";
+			}
+
+			this->m_bLoadingOperationInitiated = false;
+		}
+	}
+
+	if(ImGui::BeginPopupModal("Load Failed", NULL, ImGuiWindowFlags_AlwaysAutoResize))
+	{
+		ImGui::Text("Load game failed.\n");
+		ImGui::Text(loadFailedPopupText.c_str());
+		ImGui::Separator();
+
+		if(ImGui::Button("Okay", ImVec2(120, 0)))
+		{
+			ImGui::CloseCurrentPopup();
+		}
+		ImGui::EndPopup();
 	}
 
 	ImGui::End();

--- a/spacegame7/LoadGamePanel.hxx
+++ b/spacegame7/LoadGamePanel.hxx
@@ -5,22 +5,9 @@
 class LoadGamePanel : public InterfacePanel
 {
 public:
-	LoadGamePanel()
-	{
-		if (this->m_bPanelExists)
-		{
-			this->m_bPanelActive = false;
-		}
-		else
-		{
-			this->m_bPanelActive = true;
-			this->m_bPanelExists = true;
-		}
-	};
-	virtual ~LoadGamePanel()
-	{
-		this->m_bPanelExists = false;
-	};
+	LoadGamePanel();
+
+	virtual ~LoadGamePanel();
 
 	virtual void render_panel(float const flDelta);
 
@@ -34,4 +21,6 @@ public:
 private:
 	static bool m_bPanelExists;
 	bool m_bPanelActive;
+	bool m_bLoadingOperationInitiated;
+	std::future<bool> m_fLoadingOperationResult;
 };

--- a/spacegame7/LoadoutPanel.cxx
+++ b/spacegame7/LoadoutPanel.cxx
@@ -1,0 +1,137 @@
+#include "LoadoutPanel.hxx"
+
+#include "CWorldTransaction.hxx"
+
+void LoadoutPanel::render_panel(float const flDelta)
+{
+	CWorldTransaction wTransaction;
+
+	if(!SG::get_engine()->instance_is_allocated(this->m_iObjectId))
+	{
+		return;
+	}
+
+	IWorldInstance* pInstance = SG::get_engine()->instance_get(this->m_iObjectId);
+
+	if(pInstance == nullptr)
+	{
+		return;
+	}
+
+	ImGui::Begin("Equipment", nullptr, ImGuiWindowFlags_NoFocusOnAppearing);
+
+	//pInstance->instance_acquired();
+
+	//is our linked object a CEquippedObject?
+	if(pInstance->instance_get_flags() & CEquippedObject::InstanceFlag)
+	{
+		CEquippedObject* pEquippedObject = static_cast<CEquippedObject*>(pInstance);
+
+		std::vector<InstanceId> vObjectChildren = pEquippedObject->get_children();
+
+		//now, walk each child of the equipped object (its equipment instances)
+		for(InstanceId instanceId : vObjectChildren)
+		{
+			if(!SG::get_engine()->instance_is_allocated(instanceId))
+			{
+				continue;
+			}
+
+			CEquipInstance* pChildEquip = SG::get_engine()->instance_get_checked<CEquipInstance>(instanceId);
+
+			if(pChildEquip == nullptr)
+			{
+				continue;
+			}
+
+			//pChildEquip->instance_acquired();
+
+			Archetype const* pChildArch = pChildEquip->get_archetype();
+			EquipArch const* pChildEquipArch = reinterpret_cast<EquipArch const*>(pChildArch);
+
+			bool bChildEnabled = pChildEquip->is_alive();
+
+			//the color will be either green or yellow depending on if the piece of
+			//equipment is enabled
+			ImVec4 vColor = bChildEnabled ? ImVec4(0.0f, 1.0f, 0.0f, 1.0f) : ImVec4(1.0f, 1.0f, 0.0f, 1.0f);
+
+			ImGui::PushID(instanceId);
+			ImGui::PushStyleColor(ImGuiCol_Text, vColor);
+			if(ImGui::Selectable(pChildEquipArch->szEquipName.c_str()))
+			{
+				pChildEquip->alive_set(!bChildEnabled);
+			}
+			ImGui::PopStyleColor(1);
+			ImGui::PopID();
+
+			//if the user hovers over a piece of equipment, display a tooltip
+			//with the item's description and statistics
+			if(ImGui::IsItemHovered())
+			{
+				LoadoutPanel::do_item_tooltip(pChildEquipArch);
+			}
+
+			//pChildEquip->instance_released();
+		}
+	}
+
+	//pInstance->instance_released();
+
+	ImGui::End();
+}
+
+void LoadoutPanel::do_item_tooltip(EquipArch const* pEquipArch)
+{
+	ImGui::BeginTooltip();
+
+	ImGui::Text(pEquipArch->szEquipName.c_str());
+
+	ImGui::Separator();
+
+	switch(pEquipArch->uiArchType)
+	{
+		case ARCH_WEAPON:
+		{
+			WeaponArch const* pWeapArch = reinterpret_cast<WeaponArch const*>(pEquipArch);
+			ImGui::Text("Weapon");
+			ImGui::Text(pEquipArch->szEquipDescription.c_str());
+			ImGui::Text("Hull DPS:");
+			ImGui::SameLine();
+			ImGui::Text(Conversion::float_to_string(pWeapArch->get_hull_dps()).c_str());
+			ImGui::Text("Shield DPS:");
+			ImGui::SameLine();
+			ImGui::Text(Conversion::float_to_string(pWeapArch->get_shield_dps()).c_str());
+			ImGui::Text("Range:");
+			ImGui::SameLine();
+			ImGui::Text(Conversion::float_to_string(pWeapArch->get_range()).c_str());
+			break;
+		}
+		case ARCH_MISSILE:
+		{
+			MissileArch const* pWeapArch = reinterpret_cast<MissileArch const*>(pEquipArch);
+			ImGui::Text("Missile");
+			ImGui::Text(pEquipArch->szEquipDescription.c_str());
+			ImGui::Text("Hull DMG:");
+			ImGui::SameLine();
+			ImGui::Text(Conversion::float_to_string(pWeapArch->flHullDamage).c_str());
+			ImGui::Text("Shield DMG:");
+			ImGui::SameLine();
+			ImGui::Text(Conversion::float_to_string(pWeapArch->flShieldDamage).c_str());
+			ImGui::Text("Accel.:");
+			ImGui::SameLine();
+			ImGui::Text(Conversion::float_to_string(pWeapArch->flMotorAcceleration).c_str());
+			ImGui::Text("Seek Time:");
+			ImGui::SameLine();
+			ImGui::Text(Conversion::float_to_string(pWeapArch->flMotorLifetime).c_str());
+			//ImGui::Text("Range:");
+			//ImGui::SameLine();
+			//ImGui::Text(Conversion::float_to_string(pWeapArch->get_range()).c_str());
+			break;
+		}
+		default:
+		{
+
+		}
+	}
+	ImGui::EndTooltip();
+}

--- a/spacegame7/LoadoutPanel.cxx
+++ b/spacegame7/LoadoutPanel.cxx
@@ -44,10 +44,31 @@ void LoadoutPanel::render_panel(float const flDelta)
 				continue;
 			}
 
+			CWeaponInstance* pWeapInstance = nullptr;
+
+			if(pChildEquip->instance_get_flags() & CWeaponInstance::InstanceFlag)
+			{
+				pWeapInstance = static_cast<CWeaponInstance*>(pChildEquip);
+			}
+
 			//pChildEquip->instance_acquired();
 
 			Archetype const* pChildArch = pChildEquip->get_archetype();
 			EquipArch const* pChildEquipArch = reinterpret_cast<EquipArch const*>(pChildArch);
+
+			std::string szWeaponNameText(pChildEquipArch->szEquipName.c_str());
+
+			if(pWeapInstance != nullptr && pChildArch->uiArchType == MissileArch::Type)
+			{
+				float flRefireTime = pWeapInstance->get_refire_time_remaining();
+
+				if(flRefireTime > 0.0f)
+				{
+					szWeaponNameText.append(" [");
+					szWeaponNameText.append(Conversion::float_to_string(flRefireTime));
+					szWeaponNameText.append("]");
+				}
+			}
 
 			bool bChildEnabled = pChildEquip->is_alive();
 
@@ -57,7 +78,7 @@ void LoadoutPanel::render_panel(float const flDelta)
 
 			ImGui::PushID(instanceId);
 			ImGui::PushStyleColor(ImGuiCol_Text, vColor);
-			if(ImGui::Selectable(pChildEquipArch->szEquipName.c_str()))
+			if(ImGui::Selectable(szWeaponNameText.c_str()))
 			{
 				pChildEquip->alive_set(!bChildEnabled);
 			}

--- a/spacegame7/LoadoutPanel.hxx
+++ b/spacegame7/LoadoutPanel.hxx
@@ -2,10 +2,8 @@
 
 #include <sstream>
 
-#include "InterfacePanel.hxx"
-
 #include "CEquippedObject.hxx"
-#include "CWorldTransaction.hxx"
+#include "InterfacePanel.hxx"
 
 class LoadoutPanel : public InterfacePanel
 {
@@ -16,139 +14,9 @@ public:
 	virtual ~LoadoutPanel()
 	{};
 
-	virtual void render_panel(float const flDelta)
-	{
-		CWorldTransaction wTransaction;
+	virtual void render_panel(float const);
 
-		if(!SG::get_engine()->instance_is_allocated(this->m_iObjectId))
-		{
-			return;
-		}
-
-		IWorldInstance *pInstance = SG::get_engine()->instance_get(this->m_iObjectId);
-
-		if(pInstance == nullptr)
-		{
-			return;
-		}
-
-		ImGui::Begin("Equipment", nullptr, ImGuiWindowFlags_NoFocusOnAppearing);
-
-		//pInstance->instance_acquired();
-
-		//is our linked object a CEquippedObject?
-		if(pInstance->instance_get_flags() & CEquippedObject::InstanceFlag)
-		{
-			CEquippedObject *pEquippedObject = static_cast<CEquippedObject*>(pInstance);
-
-			std::vector<InstanceId> vObjectChildren = pEquippedObject->get_children();
-
-			//now, walk each child of the equipped object (its equipment instances)
-			for(InstanceId instanceId : vObjectChildren)
-			{
-				if(!SG::get_engine()->instance_is_allocated(instanceId))
-				{
-					continue;
-				}
-
-				CEquipInstance *pChildEquip = SG::get_engine()->instance_get_checked<CEquipInstance>(instanceId);
-
-				if(pChildEquip == nullptr)
-				{
-					continue;
-				}
-
-				//pChildEquip->instance_acquired();
-
-				Archetype const *pChildArch = pChildEquip->get_archetype();
-				EquipArch const *pChildEquipArch = reinterpret_cast<EquipArch const*>(pChildArch);
-
-				bool bChildEnabled = pChildEquip->is_alive();
-
-				//the color will be either green or yellow depending on if the piece of
-				//equipment is enabled
-				ImVec4 vColor = bChildEnabled ? ImVec4(0.0f, 1.0f, 0.0f, 1.0f) : ImVec4(1.0f, 1.0f, 0.0f, 1.0f);
-
-				ImGui::PushID(instanceId);
-				ImGui::PushStyleColor(ImGuiCol_Text, vColor);
-				if(ImGui::Selectable(pChildEquipArch->szEquipName.c_str()))
-				{
-					pChildEquip->alive_set(!bChildEnabled);
-				}
-				ImGui::PopStyleColor(1);
-				ImGui::PopID();
-
-				//if the user hovers over a piece of equipment, display a tooltip
-				//with the item's description and statistics
-				if(ImGui::IsItemHovered())
-				{
-					LoadoutPanel::do_item_tooltip(pChildEquipArch);
-				}
-
-				//pChildEquip->instance_released();
-			}
-		}
-
-		//pInstance->instance_released();
-
-		ImGui::End();
-	};
-
-	static void do_item_tooltip(EquipArch const *pEquipArch)
-	{
-		ImGui::BeginTooltip();
-
-		ImGui::Text(pEquipArch->szEquipName.c_str());
-
-		ImGui::Separator();
-
-		switch(pEquipArch->uiArchType)
-		{
-			case ARCH_WEAPON:
-			{
-				WeaponArch const *pWeapArch = reinterpret_cast<WeaponArch const*>(pEquipArch);
-				ImGui::Text("Weapon");
-				ImGui::Text(pEquipArch->szEquipDescription.c_str());
-				ImGui::Text("Hull DPS:");
-				ImGui::SameLine();
-				ImGui::Text(Conversion::float_to_string(pWeapArch->get_hull_dps()).c_str());
-				ImGui::Text("Shield DPS:");
-				ImGui::SameLine();
-				ImGui::Text(Conversion::float_to_string(pWeapArch->get_shield_dps()).c_str());
-				ImGui::Text("Range:");
-				ImGui::SameLine();
-				ImGui::Text(Conversion::float_to_string(pWeapArch->get_range()).c_str());
-				break;
-			}
-			case ARCH_MISSILE:
-			{
-				MissileArch const *pWeapArch = reinterpret_cast<MissileArch const*>(pEquipArch);
-				ImGui::Text("Missile");
-				ImGui::Text(pEquipArch->szEquipDescription.c_str());
-				ImGui::Text("Hull DMG:");
-				ImGui::SameLine();
-				ImGui::Text(Conversion::float_to_string(pWeapArch->flHullDamage).c_str());
-				ImGui::Text("Shield DMG:");
-				ImGui::SameLine();
-				ImGui::Text(Conversion::float_to_string(pWeapArch->flShieldDamage).c_str());
-				ImGui::Text("Accel.:");
-				ImGui::SameLine();
-				ImGui::Text(Conversion::float_to_string(pWeapArch->flMotorAcceleration).c_str());
-				ImGui::Text("Seek Time:");
-				ImGui::SameLine();
-				ImGui::Text(Conversion::float_to_string(pWeapArch->flMotorLifetime).c_str());
-				//ImGui::Text("Range:");
-				//ImGui::SameLine();
-				//ImGui::Text(Conversion::float_to_string(pWeapArch->get_range()).c_str());
-				break;
-			}
-			default:
-			{
-
-			}
-		}
-		ImGui::EndTooltip();
-	};
+	static void do_item_tooltip(EquipArch const*);
 
 	virtual bool panel_active(void)
 	{

--- a/spacegame7/PlayerDiedPanel.hxx
+++ b/spacegame7/PlayerDiedPanel.hxx
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <future>
+
 #include "InterfacePanel.hxx"
 
 class PlayerDiedPanel : public InterfacePanel
@@ -36,4 +38,5 @@ private:
 	std::string m_szDeathString;
 	static bool m_bPanelExists;
 	bool m_bPanelActive;
+	std::future<bool> m_bGameLoadAttempt;
 };

--- a/spacegame7/SkillTreePanel.cxx
+++ b/spacegame7/SkillTreePanel.cxx
@@ -139,7 +139,7 @@ void SkillTreePanel::render_panel(float const flDelta)
 		ImGui::SetCursorPos(ImVec2(windowSize.x - (windowSize.x / 2.0f) - 32.0f, cursorPos.y));
 
 		bool bHasLegendarySkill = this->m_pEntity->has_skill(this->m_pCurrentLegendarySkill->get_id());
-		bool bCanAcquireLegendarySkill = !bHasLegendarySkill && (totalSkillsInTree == skillsAcquiredInTree);
+		bool bCanAcquireLegendarySkill = !bHasLegendarySkill && (totalSkillsInTree == skillsAcquiredInTree) && (uiFreeSkillPoints > 0U);
 
 		render_skill_button(this->m_pCurrentLegendarySkill, true, bHasLegendarySkill, bCanAcquireLegendarySkill);
 	}

--- a/spacegame7/spacegame7.vcxproj
+++ b/spacegame7/spacegame7.vcxproj
@@ -269,6 +269,7 @@
     <ClCompile Include="InGameMenuPanel.cxx" />
     <ClCompile Include="JunkTraderPanel.cxx" />
     <ClCompile Include="LoadGamePanel.cxx" />
+    <ClCompile Include="LoadoutPanel.cxx" />
     <ClCompile Include="MaterialBankPanel.cxx" />
     <ClCompile Include="MaterialExaminePanel.cxx" />
     <ClCompile Include="NotificationPanel.cxx" />

--- a/spacegame7/spacegame7.vcxproj.filters
+++ b/spacegame7/spacegame7.vcxproj.filters
@@ -436,6 +436,9 @@
     <ClCompile Include="NotificationPanel.cxx">
       <Filter>Engine\Interface</Filter>
     </ClCompile>
+    <ClCompile Include="LoadoutPanel.cxx">
+      <Filter>Engine\Interface</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="IEngine.hxx">


### PR DESCRIPTION
Fixed the bug with legendary skills in UI showing as available in the wrong circumstances.

Added a refire timer to the equipment panel, visible only for missiles.

Rewrote save loading as an asynchronous operation. UI panels which initiate savegame loads now check back on the status of the load and display an error message if necessary.